### PR TITLE
Add reference to ReverseIterableMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ for (let v of a[Symbol.reverseIterator]()) {
 }
 ```
 
-
 This syntax has the benefit of not introducing new syntactical concepts but
 instead just adds a few function properties to iterator prototypes.
 
@@ -58,6 +57,7 @@ adding a function to the `Symbol.reverseIterator` property. Capturing this in an
 interface allows arbitrary code to detect that a particular object is reverse
 iterable and use that to it's advantage.
 
+Further examples and a working reference implemenation of a reverse-iterable map can be found here: [ReverseIterableMap](https://github.com/kleinfreund/reverse-iterable-map).
 
 ## FAQ
 


### PR DESCRIPTION
I’m not quite sure where to add this and if it’s still useful. Maybe it is.

For rerefence, the node package can be found here: https://www.npmjs.com/package/reverse-iterable-map

---

In the meantime, I implemented the following:

- [`ReverseIterableArray`](https://www.npmjs.com/package/reverse-iterable-array) (extends `Array`; overrides iterator methods, but nothing else in the prototype)
- [`ReverseIterableSet`](https://www.npmjs.com/package/reverse-iterable-set)